### PR TITLE
Added support for mailto links with parameters

### DIFF
--- a/src/Obfuscator.php
+++ b/src/Obfuscator.php
@@ -26,7 +26,7 @@ function obfuscateEmail($string)
 
     // Define patterns for extracting emails.
     $patterns = array(
-        '|\<a([^>]+)href\=\"mailto\:([^">]+)\"([^>]*)\>(.*?)\<\/a\>|ism', // mailto anchors
+        '|\<a([^>]+)href\=\"mailto\:([^">?]+)(\?[^?">]+)?\"([^>]*)\>(.*?)\<\/a\>|ism', // mailto anchors
         '|[_a-z0-9-]+(?:\.[_a-z0-9-]+)*@[a-z0-9-]+(?:\.[a-z0-9-]+)*(?:\.[a-z]{2,3})|i', // plain emails
     );
 
@@ -41,7 +41,7 @@ function obfuscateEmail($string)
             // Reversed direction implementation for non-JS browsers
             if (stripos($parts[0], '<a') === 0) {
                 // Mailto tag; if link content equals the email, just display the email, otherwise display a formatted string.
-                $nojs = ($parts[1] == $parts[2]) ? $parts[1] : ($parts[2] . ' > ' . $parts[1] . ' <');
+                $nojs = ($parts[1] == $parts[3]) ? $parts[1] : ($parts[3] . ' > ' . $parts[1] . ' <');
             } else {
                 // Plain email; display the plain email.
                 $nojs = $parts[0];


### PR DESCRIPTION
Obfuscator will now support a mail to link with parameters like the following :

`<a href="mailto:guy@domain.com?Subject=Hi&Body=ContentOfTheMail">Send Guy a Message</a>`