### PR TITLE
Update Obfuscator.php

### DIFF
--- a/src/Obfuscator.php
+++ b/src/Obfuscator.php
@@ -14,7 +14,7 @@ function obfuscateEmail($string)
 
     // Safeguard several stuff before parsing.
     $prevent = array(
-        '|<input .*@.*>|is', // <input>
+        '|<input [^>]*@[^>]*>|is', // <input>
         '|(<head(?:[^>]*)>)(.*?)(</head>)|is', // <head>
         '|(<script(?:[^>]*)>)(.*?)(</script>)|is', // <script>
     );


### PR DESCRIPTION
<input .*@.*> would match a line such as:
    `<input type="text"> Mail to: someone@example.com` 

This would cause every '@' following the input element to be replaced by the safeguard, rendering the obfuscation useless. 

The new regex will only match a single input tag now, but will fail on `<input name="stupid>name" value="someone@example.com">`. This seems to be a more favourable trade off at the moment.